### PR TITLE
Legacy account support

### DIFF
--- a/lib/passport-youtube/strategy.js
+++ b/lib/passport-youtube/strategy.js
@@ -60,11 +60,16 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       var youtubeProfile = json.entry;
 
       var profile = { provider: 'youtube' };
-      profile.id = youtubeProfile["yt$googlePlusUserId"]["$t"];
+
+      profile.id = (youtubeProfile["yt$googlePlusUserId"]) ? youtubeProfile["yt$googlePlusUserId"]["$t"] : youtubeProfile["yt$username"]["$t"];
       profile.username = youtubeProfile["yt$username"]["$t"];
       profile.displayName = youtubeProfile["title"]["$t"];
-      profile.name = { familyName: youtubeProfile["yt$lastName"]["$t"],
-                       givenName: youtubeProfile["yt$firstName"]["$t"]};
+      if(youtubeProfile["yt$lastName"] && youtubeProfile["yt$firstName"]) {
+        profile.name = { familyName: youtubeProfile["yt$lastName"]["$t"], givenName: youtubeProfile["yt$firstName"]["$t"] };
+      } else {
+        profile.name = { familyName: "", givenName: youtubeProfile["title"]["$t"]};
+      }
+      
 
       profile._raw = body;
       profile._json = json;


### PR DESCRIPTION
Account like mine that haven't yet transfered to google plus are missing the `firstname`, `lastname` and `yt$googlePlusUserId`. Added a few checked to go around these.
